### PR TITLE
Update Maintainerr github_slug after repo rename

### DIFF
--- a/arr-services.json
+++ b/arr-services.json
@@ -116,7 +116,7 @@
 		{
 			"name": "Maintainerr",
 			"description": "Maintenance tool for the Plex ecosystem",
-			"github_slug": "jorenn92/Maintainerr"
+			"github_slug": "Maintainerr/Maintainerr"
 		},
 		{
 			"name": "Monitorr",


### PR DESCRIPTION
## Summary

Updates the Maintainerr entry's `github_slug` after the upstream repo rename.

On 2026-01-31 the Maintainerr project moved from `jorenn92/Maintainerr` to [`Maintainerr/Maintainerr`](https://github.com/Maintainerr/Maintainerr) on GitHub. The old slug still redirects, but pointing directly at the canonical org keeps the index accurate and ensures any feature that surfaces the slug as a label or builds derived URLs (releases, stars, etc.) reflects the current home.

## Changes

In `arr-services.json`, the Maintainerr entry under `applications`:

```diff
   {
     "name": "Maintainerr",
     "description": "Maintenance tool for the Plex ecosystem",
-    "github_slug": "jorenn92/Maintainerr"
+    "github_slug": "Maintainerr/Maintainerr"
   }
```

## Test plan

- [ ] Verify the rendered site still lists Maintainerr and any GitHub-derived metadata (stars, latest release) loads correctly
