### PR TITLE
Add arrstack and Bazarr+

### DIFF
--- a/arr-services.json
+++ b/arr-services.json
@@ -259,13 +259,8 @@
 			"github_slug": "pennydreadful/bookshelf"
 		},
 		{
-			"name": "arrstack",
-			"description": "Single-binary TUI installer that sets up and auto-wires a 12-service self-hosted media stack (Sonarr, Radarr, Bazarr+, Jellyfin, Jellyseerr, Prowlarr, qBittorrent, Tdarr, Trailarr, FlareSolverr) on a clean Linux host in about 90 seconds.",
-			"github_slug": "LavX/arrstack"
-		},
-		{
 			"name": "Bazarr+",
-			"description": "Hard fork of Bazarr adding a full in-app subtitle editor (video + waveform, per-cue AI translation via OpenRouter, ffsubsync), OpenSubtitles.org scraper, mass batch operations, provider-priority search, and encrypted API keys.",
+			"description": "Fork of Bazarr adding a subtitle editor, OpenSubtitles.org scraper, mass batch operations, provider-priority search, and encrypted API keys",
 			"github_slug": "LavX/bazarr"
 		}
 	]

--- a/arr-services.json
+++ b/arr-services.json
@@ -257,6 +257,16 @@
 			"name": "Bookshelf",
 			"description": "A drop in replacement for Readarr to manage **ebooks** and **audiobooks**",
 			"github_slug": "pennydreadful/bookshelf"
+		},
+		{
+			"name": "arrstack",
+			"description": "Single-binary TUI installer that sets up and auto-wires a 12-service self-hosted media stack (Sonarr, Radarr, Bazarr+, Jellyfin, Jellyseerr, Prowlarr, qBittorrent, Tdarr, Trailarr, FlareSolverr) on a clean Linux host in about 90 seconds.",
+			"github_slug": "LavX/arrstack"
+		},
+		{
+			"name": "Bazarr+",
+			"description": "Hard fork of Bazarr adding a full in-app subtitle editor (video + waveform, per-cue AI translation via OpenRouter, ffsubsync), OpenSubtitles.org scraper, mass batch operations, provider-priority search, and encrypted API keys.",
+			"github_slug": "LavX/bazarr"
 		}
 	]
 }

--- a/other-helpful-apps.json
+++ b/other-helpful-apps.json
@@ -76,6 +76,11 @@
 			"name": "Unmanic",
 			"description": "Transcodes your library",
 			"github_slug": "josh5/unmanic"
+		},
+		{
+			"name": "arrstack",
+			"description": "TUI installer that sets up a TRaSH-compliant self-hosted media stack on a clean Linux host",
+			"github_slug": "LavX/arrstack"
 		}
 	]
 }


### PR DESCRIPTION
Two new entries for `arr-services.json`, picked up by the existing alphabetical sort at render time.

### arrstack (`LavX/arrstack`)
Single-binary TUI installer that sets up and auto-wires a 12-service self-hosted media stack (Sonarr, Radarr, Bazarr+, Jellyfin, Jellyseerr, Prowlarr, qBittorrent, Tdarr, Trailarr, FlareSolverr) on a clean Linux host in about 90 seconds. Writes a TRaSH-compliant compose file via Recyclarr, runs `docker compose up -d`, then calls every service's API so the first boot is already wired. Linux x86_64 and arm64. MIT. [lavx.github.io/arrstack](https://lavx.github.io/arrstack/)

### Bazarr+ (`LavX/bazarr`)
Hard fork of Bazarr adding a full in-app subtitle editor (video preview, waveform timeline, per-cue AI translation via OpenRouter, ffsubsync), OpenSubtitles.org scraper, mass batch operations, provider-priority search, and encrypted API keys. Shipped a stable v2.0.0 "Eclipse" (243 commits) and is preparing v2.1.0 "LiveWire" (54 more commits). Listed separately from upstream `morpheus65535/bazarr` because the divergence is substantial and the audiences are distinct. GPL-3.0.

### Checklist
- [x] Entries added to `arr-services.json`
- [x] JSON parses (`jq 'length'` = 52)
- [x] Tab indentation matches the rest of the file
- [x] Both repos are public, maintained, and carry OSI-approved licenses (MIT / GPL-3.0)